### PR TITLE
fix: loading state in view detail page

### DIFF
--- a/frontend/src/components/workout/view/WorkoutDetailsSkeleton.tsx
+++ b/frontend/src/components/workout/view/WorkoutDetailsSkeleton.tsx
@@ -1,0 +1,89 @@
+import { Skeleton } from '@mui/material';
+
+const skeletonCards = Array.from({ length: 3 }, (_, index) => index);
+const skeletonSets = Array.from({ length: 3 }, (_, index) => index);
+const skeletonBgColor = 'var(--color-skeleton)';
+
+const ExerciseCardSkeleton = () => (
+  <div className="bg-secondary p-4 rounded-2xl mb-4 border border-white/5">
+    <div className="flex justify-between items-center mb-4">
+      <div className="flex-1">
+        <Skeleton
+          variant="text"
+          width="52%"
+          height={32}
+          sx={{ bgcolor: skeletonBgColor }}
+        />
+        <Skeleton
+          variant="text"
+          width={56}
+          height={18}
+          sx={{ bgcolor: skeletonBgColor }}
+        />
+      </div>
+    </div>
+
+    <div className="space-y-3">
+      {skeletonSets.map((setIndex) => (
+        <div key={setIndex} className="flex gap-3 items-center">
+          <Skeleton
+            variant="text"
+            width={24}
+            height={24}
+            sx={{ bgcolor: skeletonBgColor }}
+          />
+          <Skeleton
+            variant="rounded"
+            className="flex-1"
+            height={60}
+            sx={{ bgcolor: skeletonBgColor, borderRadius: '0.75rem' }}
+          />
+          <Skeleton
+            variant="rounded"
+            className="flex-1"
+            height={60}
+            sx={{ bgcolor: skeletonBgColor, borderRadius: '0.75rem' }}
+          />
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+export const WorkoutDetailsSkeleton = () => {
+  return (
+    <div
+      className="min-h-screen bg-main text-white pb-6"
+      data-testid="workout-details-skeleton"
+    >
+      <div className="sticky top-0 z-20 bg-main/80 backdrop-blur-md border-b border-white/5 px-4 py-4 flex items-center gap-4">
+        <Skeleton
+          variant="circular"
+          width={24}
+          height={24}
+          sx={{ bgcolor: skeletonBgColor, flexShrink: 0 }}
+        />
+        <div className="flex-1">
+          <Skeleton
+            variant="text"
+            width="58%"
+            height={36}
+            sx={{ bgcolor: skeletonBgColor }}
+          />
+          <Skeleton
+            variant="text"
+            width={120}
+            height={18}
+            sx={{ bgcolor: skeletonBgColor }}
+          />
+        </div>
+      </div>
+
+      <div className="px-4 py-6 max-w-md mx-auto">
+        {skeletonCards.map((cardIndex) => (
+          <ExerciseCardSkeleton key={cardIndex} />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/workout/view/index.ts
+++ b/frontend/src/components/workout/view/index.ts
@@ -1,2 +1,3 @@
 export { ViewExerciseCard } from './ViewExerciseCard';
 export { ViewExercisesList } from './ViewExercisesList';
+export { WorkoutDetailsSkeleton } from './WorkoutDetailsSkeleton';

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -6,6 +6,7 @@
   --color-primary: #8cef0d;
   --color-muted: #9c9d9f;
   --color-secondary: #1c1c1e;
+  --color-skeleton: rgba(255, 255, 255, 0.08);
 }
 
 :root {

--- a/frontend/src/locales/en/workout.ts
+++ b/frontend/src/locales/en/workout.ts
@@ -11,6 +11,7 @@ export const workoutLocales = {
   view: {
     idAllowed: 'ID undefined',
     notFound: 'Workout not found',
+    error: 'Failed to load workout',
   },
   weight: 'Weight',
   reps: 'Reps',

--- a/frontend/src/pages/workout/create/CreateWorkoutPage.tsx
+++ b/frontend/src/pages/workout/create/CreateWorkoutPage.tsx
@@ -30,7 +30,14 @@ const CreateWorkoutPage = () => {
       onSubmit={handleSubmit}
       validateOnMount
     >
-      {({ values, handleChange, isSubmitting, isValid, errors, submitCount }) => (
+      {({
+        values,
+        handleChange,
+        isSubmitting,
+        isValid,
+        errors,
+        submitCount,
+      }) => (
         <Form className="min-h-screen bg-main text-white pb-32">
           <StickyHeader
             name={values.name}

--- a/frontend/src/pages/workout/specs/ViewWorkoutPage.spec.tsx
+++ b/frontend/src/pages/workout/specs/ViewWorkoutPage.spec.tsx
@@ -19,14 +19,36 @@ describe('ViewWorkoutPage', () => {
   const mockUseGetWorkoutById = useGetWorkoutById as jest.Mock;
   const mockedUseParams = useParams as jest.Mock;
   const mockId = 'id-example';
+  // TODO: extract shared workout route test helper if this file gets another URL variant.
 
   beforeEach(() => {
     jest.clearAllMocks();
     mockedUseParams.mockReturnValue({ id: mockId });
   });
 
-  it('should show notFound message if workout data not loaded or undefined', () => {
-    mockUseGetWorkoutById.mockReturnValue({ data: null });
+  it('should show skeleton while workout is loading for the first time', () => {
+    mockUseGetWorkoutById.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      error: null,
+    });
+
+    render(<ViewWorkoutPage />, { route: `/workout/${mockId}` });
+
+    expect(screen.getByTestId('workout-details-skeleton')).toBeInTheDocument();
+  });
+
+  it('should show notFound message only when request returns 404', () => {
+    mockUseGetWorkoutById.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: {
+        isAxiosError: true,
+        response: { status: 404 },
+      },
+    });
 
     render(<ViewWorkoutPage />, { route: `/workout/${mockId}` });
 
@@ -35,13 +57,33 @@ describe('ViewWorkoutPage', () => {
     ).toBeInTheDocument();
   });
 
+  it('should show distinct error state for non-404 errors', () => {
+    mockUseGetWorkoutById.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: {
+        response: { status: 500 },
+      },
+    });
+
+    render(<ViewWorkoutPage />, { route: `/workout/${mockId}` });
+
+    expect(screen.getByText(DICTIONARY.workout.view.error)).toBeInTheDocument();
+  });
+
   it('should render header with workout name if data loaded', () => {
     const mockData = {
       name: 'Push Up Session',
       date: '2023-10-27T00:00:00.000Z',
       exercises: [],
     };
-    mockUseGetWorkoutById.mockReturnValue({ data: mockData });
+    mockUseGetWorkoutById.mockReturnValue({
+      data: mockData,
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
 
     render(<ViewWorkoutPage />, { route: `/workout/${mockId}` });
 

--- a/frontend/src/pages/workout/view/ViewWorkoutPage.tsx
+++ b/frontend/src/pages/workout/view/ViewWorkoutPage.tsx
@@ -1,23 +1,46 @@
 import { useParams } from 'react-router-dom';
 
 import { DICTIONARY } from '@locales';
-import { StickyHeader, ViewExercisesList } from '@components';
+import {
+  StickyHeader,
+  ViewExercisesList,
+  WorkoutDetailsSkeleton,
+} from '@components';
 import { useGetWorkoutById } from '../queries';
+
+const isNotFoundError = (error: unknown) =>
+  typeof error === 'object' &&
+  error !== null &&
+  'response' in error &&
+  (error as { response?: { status?: number } }).response?.status === 404;
 
 const ViewWorkoutPage = () => {
   const { id } = useParams();
   const infoStyles =
     'w-full h-screen flex items-center justify-center text-center text-xl';
 
-  const { data } = useGetWorkoutById(id!);
-  if (!data) {
+  const { data, error, isLoading, isError } = useGetWorkoutById(id!);
+
+  if (isLoading && !data) {
+    return <WorkoutDetailsSkeleton />;
+  }
+
+  if (isError && isNotFoundError(error)) {
     return <div className={infoStyles}>{DICTIONARY.workout.view.notFound}</div>;
+  }
+
+  if (isError) {
+    return <div className={infoStyles}>{DICTIONARY.workout.view.error}</div>;
+  }
+
+  if (!data) {
+    return <WorkoutDetailsSkeleton />;
   }
 
   return (
     <>
-      <StickyHeader name={data?.name} date={data?.date} readOnly />
-      <ViewExercisesList exercises={data?.exercises} />
+      <StickyHeader name={data.name} date={data.date} readOnly />
+      <ViewExercisesList exercises={data.exercises} />
     </>
   );
 };


### PR DESCRIPTION
## Description

This change fixes the first-load experience on the workout details page. Instead of briefly showing an incorrect "Workout not found" message while the request is still in flight, the page now shows a skeleton state that matches the final layout and separates loading, not-found, error, and success states. As a result, direct navigation to workout details feels stable and no longer flickers through a false negative state.

## Related Issue

- [Issue #25](https://github.com/filippovskii09/fit-tracker-corp/issues/25)
