### PR TITLE
fix: remove css overrides for accardion

### DIFF
--- a/frontend/src/components/workout/view/ViewExerciseCard.tsx
+++ b/frontend/src/components/workout/view/ViewExerciseCard.tsx
@@ -19,9 +19,12 @@ export const ViewExerciseCard = ({ exercise }: IViewExerciseCardProps) => {
         flexDirection: 'column',
         marginBottom: '20px',
         backgroundColor: 'var(--secondary)',
-        borderRadius: '20px',
+        borderRadius: 'var(--border-radius-3xl, 1.5rem) !important',
         border: '1px solid rgba(255, 255, 255, 0.05)',
         padding: '20px',
+        '&::before': {
+          content: 'none',
+        },
       }}
     >
       {/* Exercise name */}

--- a/frontend/src/components/workout/view/ViewExerciseCard.tsx
+++ b/frontend/src/components/workout/view/ViewExerciseCard.tsx
@@ -5,8 +5,6 @@ import type { ISet } from '@types';
 import { DICTIONARY } from '@locales';
 import type { IViewExerciseCardProps } from '../types';
 
-import './accardion.css';
-
 export const ViewExerciseCard = ({ exercise }: IViewExerciseCardProps) => {
   const workoutLocales = DICTIONARY.workout;
   const exerciseName = exercise.exercise?.name || exercise.name;

--- a/frontend/src/components/workout/view/accardion.css
+++ b/frontend/src/components/workout/view/accardion.css
@@ -1,7 +1,0 @@
-.css-abkhxf-MuiPaper-root-MuiAccordion-root {
-  border-radius: var(--border-radius-3xl, 1.5rem) !important;
-}
-
-.css-abkhxf-MuiPaper-root-MuiAccordion-root::before {
-  content: none !important;
-}


### PR DESCRIPTION
## Description

In this PR were resolved some issues. In prod after build UI for accardions work uncorrect.
This was after build, custom classes for MUI changed after build and styles overrides doesn`t apply.

We fixed it with sx={} styles for MUI and it work correctly