### PR TITLE
Filippovskii/feat/delete workout

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,8 @@
     "preview": "vite preview",
     "test": "npm run tokens && jest",
     "test:watch": "npm run tokens && jest --watch",
-    "test:cov": "npm run tokens && jest --coverage"
+    "test:cov": "npm run tokens && jest --coverage",
+    "ts": "tsc -b --noEmit"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,8 @@
     "test": "npm run tokens && jest",
     "test:watch": "npm run tokens && jest --watch",
     "test:cov": "npm run tokens && jest --coverage",
-    "ts": "tsc -b --noEmit"
+    "ts": "tsc -b --noEmit",
+    "check": "npm run format && npm run lint && npm run ts && npm run tokens:check && npm run test && npm run build"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",

--- a/frontend/src/components/workout/common/StickyHeader/index.tsx
+++ b/frontend/src/components/workout/common/StickyHeader/index.tsx
@@ -2,7 +2,7 @@ import { IoMdArrowBack } from 'react-icons/io';
 import { useNavigate } from 'react-router-dom';
 
 import { DICTIONARY } from '@locales';
-import type { IStickyHeaderProps } from '../../types';
+import type { IStickyHeaderProps } from './types';
 
 export const StickyHeader = ({
   name,
@@ -44,7 +44,7 @@ export const StickyHeader = ({
           <div className="mt-1 text-sm text-red-400">{nameError}</div>
         ) : null}
       </div>
-      {actions && <div className="flex items-center gap-4">{actions}</div>}
+      {actions && <div className="flex items-center gap-3">{actions}</div>}
     </div>
   );
 };

--- a/frontend/src/components/workout/common/StickyHeader/index.tsx
+++ b/frontend/src/components/workout/common/StickyHeader/index.tsx
@@ -2,7 +2,7 @@ import { IoMdArrowBack } from 'react-icons/io';
 import { useNavigate } from 'react-router-dom';
 
 import { DICTIONARY } from '@locales';
-import type { IStickyHeaderProps } from '../types';
+import type { IStickyHeaderProps } from '../../types';
 
 export const StickyHeader = ({
   name,
@@ -10,8 +10,10 @@ export const StickyHeader = ({
   handleChange,
   readOnly = false,
   nameError,
+  actions,
 }: IStickyHeaderProps) => {
   const navigate = useNavigate();
+
   const { create } = DICTIONARY.workout;
 
   return (
@@ -42,6 +44,7 @@ export const StickyHeader = ({
           <div className="mt-1 text-sm text-red-400">{nameError}</div>
         ) : null}
       </div>
+      {actions && <div className="flex items-center gap-4">{actions}</div>}
     </div>
   );
 };

--- a/frontend/src/components/workout/common/StickyHeader/types.ts
+++ b/frontend/src/components/workout/common/StickyHeader/types.ts
@@ -1,0 +1,10 @@
+import type { ChangeEvent, ReactNode } from 'react';
+
+export interface IStickyHeaderProps {
+  name: string;
+  date: string;
+  handleChange?: (e: ChangeEvent<HTMLInputElement>) => void;
+  readOnly?: boolean;
+  nameError?: string;
+  actions?: ReactNode;
+}

--- a/frontend/src/components/workout/common/actions/DeleteWorkoutAction/hooks.ts
+++ b/frontend/src/components/workout/common/actions/DeleteWorkoutAction/hooks.ts
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+import { useRemoveWorkout } from './queries';
+
+export const useDeleteWorkoutAction = () => {
+  const { id } = useParams();
+
+  const [isDeleteWorkoutModalOpen, setIsDeleteWorkoutModalOpen] =
+    useState<boolean>(false);
+
+  const { mutateAsync: removeWorkout, isPending: isRemovingWorkout } =
+    useRemoveWorkout(id!);
+
+  const openDeleteWorkoutModal = () => {
+    setIsDeleteWorkoutModalOpen(true);
+  };
+
+  const closeDeleteWorkoutModal = () => {
+    setIsDeleteWorkoutModalOpen(false);
+  };
+
+  const confirmWorkoutDeleting = async () => {
+    closeDeleteWorkoutModal();
+    await removeWorkout();
+  };
+
+  return {
+    isDeleteWorkoutModalOpen,
+    openDeleteWorkoutModal,
+    closeDeleteWorkoutModal,
+    confirmWorkoutDeleting,
+    isRemovingWorkout,
+  };
+};

--- a/frontend/src/components/workout/common/actions/DeleteWorkoutAction/index.tsx
+++ b/frontend/src/components/workout/common/actions/DeleteWorkoutAction/index.tsx
@@ -1,0 +1,56 @@
+import { FaRegTrashAlt } from 'react-icons/fa';
+import { CircularProgress } from '@mui/material';
+
+import { DICTIONARY } from '@locales';
+import { BaseModal } from '@ui';
+import { useDeleteWorkoutAction } from './hooks';
+
+export const DeleteWorkoutAction = () => {
+  const { remove } = DICTIONARY.workout;
+  const { WORKOUT_DELETE } = DICTIONARY.modals;
+
+  const {
+    isDeleteWorkoutModalOpen,
+    openDeleteWorkoutModal,
+    closeDeleteWorkoutModal,
+    confirmWorkoutDeleting,
+    isRemovingWorkout,
+  } = useDeleteWorkoutAction();
+
+  return (
+    <>
+      <button
+        className={`relative text-red-400 w-12 h-12 flex items-center justify-center rounded-2xl bg-red-400/10 disabled:grayscale`}
+        onClick={openDeleteWorkoutModal}
+        aria-label={remove.ariaLabel}
+        disabled={isRemovingWorkout}
+      >
+        {isRemovingWorkout ? (
+          <CircularProgress
+            aria-label={remove.removing}
+            size={24}
+            sx={{
+              position: 'absolute',
+              top: '50%',
+              left: '50%',
+              marginTop: '-12px',
+              marginLeft: '-12px',
+            }}
+          />
+        ) : (
+          <FaRegTrashAlt />
+        )}
+      </button>
+
+      <BaseModal
+        open={isDeleteWorkoutModalOpen}
+        onClose={closeDeleteWorkoutModal}
+        onConfirm={confirmWorkoutDeleting}
+        title={WORKOUT_DELETE.TITLE}
+        text={WORKOUT_DELETE.TEXT}
+        cancelButtonText={WORKOUT_DELETE.CANCEL_BUTTON_TEXT}
+        confirmButtonText={WORKOUT_DELETE.CONFIRM_BUTTON_TEXT}
+      />
+    </>
+  );
+};

--- a/frontend/src/components/workout/common/actions/DeleteWorkoutAction/queries.ts
+++ b/frontend/src/components/workout/common/actions/DeleteWorkoutAction/queries.ts
@@ -1,0 +1,29 @@
+import { useQueryClient, useMutation } from '@tanstack/react-query';
+import toast from 'react-hot-toast';
+import { useNavigate } from 'react-router-dom';
+
+import { QUERY_KEYS, APP_ROUTES } from '@constants';
+import { DICTIONARY } from '@locales';
+import { workoutService } from '@services';
+import type { RemoveWorkoutResponse } from '@types';
+
+export const useRemoveWorkout = (id: string) => {
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const { remove } = DICTIONARY.workout;
+
+  return useMutation<RemoveWorkoutResponse, Error, void>({
+    mutationFn: () => workoutService.removeWorkout(id),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: [QUERY_KEYS.WORKOUTS],
+        refetchType: 'all',
+      });
+      navigate(APP_ROUTES.DASHBOARD);
+      toast.success(remove.success);
+    },
+    onError: () => {
+      toast.error(remove.error);
+    },
+  });
+};

--- a/frontend/src/components/workout/common/actions/DeleteWorkoutAction/specs/hooks.spec.ts
+++ b/frontend/src/components/workout/common/actions/DeleteWorkoutAction/specs/hooks.spec.ts
@@ -1,0 +1,86 @@
+import { act } from '@testing-library/react';
+import { useParams } from 'react-router-dom';
+
+import { renderHook } from '@testUtils';
+import { useRemoveWorkout } from '../queries';
+import { useDeleteWorkoutAction } from '../hooks';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: jest.fn(),
+}));
+
+jest.mock('../queries', () => ({
+  useRemoveWorkout: jest.fn(),
+}));
+
+describe('useDeleteWorkoutAction', () => {
+  const workoutId = 'workout-1';
+  const mockRemoveWorkout = jest.fn();
+
+  const mockedUseParams = useParams as jest.Mock;
+  const mockedUseRemoveWorkout = useRemoveWorkout as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseParams.mockReturnValue({ id: workoutId });
+    mockedUseRemoveWorkout.mockReturnValue({
+      mutateAsync: mockRemoveWorkout,
+      isPending: false,
+    });
+  });
+
+  it('should initialize delete modal as closed and pass route workout id to remove mutation', () => {
+    const { result } = renderHook(() => useDeleteWorkoutAction());
+
+    expect(result.current.isDeleteWorkoutModalOpen).toBe(false);
+    expect(result.current.isRemovingWorkout).toBe(false);
+    expect(mockedUseRemoveWorkout).toHaveBeenCalledWith(workoutId);
+  });
+
+  it('should open and close delete workout modal', () => {
+    const { result } = renderHook(() => useDeleteWorkoutAction());
+
+    act(() => {
+      result.current.openDeleteWorkoutModal();
+    });
+
+    expect(result.current.isDeleteWorkoutModalOpen).toBe(true);
+
+    act(() => {
+      result.current.closeDeleteWorkoutModal();
+    });
+
+    expect(result.current.isDeleteWorkoutModalOpen).toBe(false);
+  });
+
+  it('should close delete modal before confirming workout deletion', async () => {
+    mockRemoveWorkout.mockResolvedValue({ deleted: true });
+
+    const { result } = renderHook(() => useDeleteWorkoutAction());
+
+    act(() => {
+      result.current.openDeleteWorkoutModal();
+    });
+
+    expect(result.current.isDeleteWorkoutModalOpen).toBe(true);
+
+    await act(async () => {
+      await result.current.confirmWorkoutDeleting();
+    });
+
+    expect(result.current.isDeleteWorkoutModalOpen).toBe(false);
+    expect(mockRemoveWorkout).toHaveBeenCalledTimes(1);
+  });
+
+  it('should expose pending remove state from remove mutation', () => {
+    mockedUseRemoveWorkout.mockReturnValue({
+      mutateAsync: mockRemoveWorkout,
+      isPending: true,
+    });
+
+    const { result } = renderHook(() => useDeleteWorkoutAction());
+
+    expect(result.current.isRemovingWorkout).toBe(true);
+  });
+});

--- a/frontend/src/components/workout/common/actions/DeleteWorkoutAction/specs/queries.spec.ts
+++ b/frontend/src/components/workout/common/actions/DeleteWorkoutAction/specs/queries.spec.ts
@@ -1,0 +1,78 @@
+import { QueryClient } from '@tanstack/react-query';
+import toast from 'react-hot-toast';
+import { useNavigate } from 'react-router-dom';
+
+import { APP_ROUTES, QUERY_KEYS } from '@constants';
+import { DICTIONARY } from '@locales';
+import { workoutService } from '@services';
+import { renderHook, waitFor } from '@testUtils';
+import { useRemoveWorkout } from '../queries';
+
+jest.mock('@services', () => ({
+  workoutService: {
+    removeWorkout: jest.fn(),
+  },
+}));
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: jest.fn(),
+}));
+
+jest.mock('react-hot-toast', () => ({
+  success: jest.fn(),
+  error: jest.fn(),
+}));
+
+describe('useRemoveWorkout', () => {
+  const workoutId = 'workout-1';
+  const mockNavigate = jest.fn();
+  const removeLocales = DICTIONARY.workout.remove;
+
+  const mockedWorkoutService = workoutService as jest.Mocked<
+    typeof workoutService
+  >;
+  const mockedNavigate = useNavigate as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedNavigate.mockReturnValue(mockNavigate);
+  });
+
+  it('should remove workout, invalidate workouts, navigate to dashboard, and show success toast', async () => {
+    const invalidateQueriesSpy = jest.spyOn(
+      QueryClient.prototype,
+      'invalidateQueries',
+    );
+
+    mockedWorkoutService.removeWorkout.mockResolvedValue({ deleted: true });
+
+    const { result } = renderHook(() => useRemoveWorkout(workoutId));
+
+    result.current.mutate();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockedWorkoutService.removeWorkout).toHaveBeenCalledWith(workoutId);
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+      queryKey: [QUERY_KEYS.WORKOUTS],
+      refetchType: 'all',
+    });
+    expect(mockNavigate).toHaveBeenCalledWith(APP_ROUTES.DASHBOARD);
+    expect(toast.success).toHaveBeenCalledWith(removeLocales.success);
+  });
+
+  it('should show error toast when workout removing fails', async () => {
+    mockedWorkoutService.removeWorkout.mockRejectedValue(new Error('Failed'));
+
+    const { result } = renderHook(() => useRemoveWorkout(workoutId));
+
+    result.current.mutate();
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(mockedWorkoutService.removeWorkout).toHaveBeenCalledWith(workoutId);
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith(removeLocales.error);
+  });
+});

--- a/frontend/src/components/workout/common/actions/index.ts
+++ b/frontend/src/components/workout/common/actions/index.ts
@@ -1,0 +1,1 @@
+export * from './DeleteWorkoutAction';

--- a/frontend/src/components/workout/common/index.ts
+++ b/frontend/src/components/workout/common/index.ts
@@ -1,1 +1,2 @@
 export * from './StickyHeader';
+export * from './actions';

--- a/frontend/src/components/workout/types/index.ts
+++ b/frontend/src/components/workout/types/index.ts
@@ -1,5 +1,3 @@
-import type { ChangeEvent, ReactNode } from 'react';
-
 import type { IExercise } from '@types';
 
 export interface IExerciseCardProps {
@@ -9,15 +7,6 @@ export interface IExerciseCardProps {
 
 export interface IViewExerciseCardProps {
   exercise: IExercise;
-}
-
-export interface IStickyHeaderProps {
-  name: string;
-  date: string;
-  handleChange?: (e: ChangeEvent<HTMLInputElement>) => void;
-  readOnly?: boolean;
-  nameError?: string;
-  actions?: ReactNode;
 }
 
 export interface IExericesBlockProps {

--- a/frontend/src/components/workout/types/index.ts
+++ b/frontend/src/components/workout/types/index.ts
@@ -1,4 +1,4 @@
-import type { ChangeEvent } from 'react';
+import type { ChangeEvent, ReactNode } from 'react';
 
 import type { IExercise } from '@types';
 
@@ -17,6 +17,7 @@ export interface IStickyHeaderProps {
   handleChange?: (e: ChangeEvent<HTMLInputElement>) => void;
   readOnly?: boolean;
   nameError?: string;
+  actions?: ReactNode;
 }
 
 export interface IExericesBlockProps {

--- a/frontend/src/locales/en/modals.ts
+++ b/frontend/src/locales/en/modals.ts
@@ -5,4 +5,10 @@ export const modalsLocales = {
     CANCEL_BUTTON_TEXT: 'No',
     CONFIRM_BUTTON_TEXT: 'Yes',
   },
+  WORKOUT_DELETE: {
+    TITLE: 'Delete workout!',
+    TEXT: 'Are you want to delete this workout?',
+    CANCEL_BUTTON_TEXT: 'No',
+    CONFIRM_BUTTON_TEXT: 'Yes',
+  },
 } as const;

--- a/frontend/src/locales/en/workout.ts
+++ b/frontend/src/locales/en/workout.ts
@@ -16,6 +16,12 @@ export const workoutLocales = {
     notFound: 'Workout not found',
     error: 'Failed to load workout',
   },
+  remove: {
+    ariaLabel: 'Open delete workout modal',
+    success: 'Workout deleted successfully',
+    error: 'Failed to delete workout',
+    removing: 'Removing workout...',
+  },
   weight: 'Weight',
   reps: 'Reps',
   kg: 'kg',

--- a/frontend/src/pages/workout/view/ViewWorkoutPage.tsx
+++ b/frontend/src/pages/workout/view/ViewWorkoutPage.tsx
@@ -2,6 +2,7 @@ import { useParams } from 'react-router-dom';
 
 import { DICTIONARY } from '@locales';
 import {
+  DeleteWorkoutAction,
   StickyHeader,
   ViewExercisesList,
   WorkoutDetailsSkeleton,
@@ -39,7 +40,12 @@ const ViewWorkoutPage = () => {
 
   return (
     <main>
-      <StickyHeader name={data.name} date={data.date} readOnly />
+      <StickyHeader
+        name={data.name}
+        date={data.date}
+        readOnly
+        actions={<DeleteWorkoutAction />}
+      />
       <ViewExercisesList exercises={data.exercises} />
     </main>
   );

--- a/frontend/src/services/specs/workout.service.spec.ts
+++ b/frontend/src/services/specs/workout.service.spec.ts
@@ -7,6 +7,7 @@ jest.mock('@api', () => ({
   api: {
     get: jest.fn(),
     post: jest.fn(),
+    delete: jest.fn(),
   },
 }));
 
@@ -14,6 +15,7 @@ describe('WorkoutService', () => {
   const mockedApi = api as jest.Mocked<typeof api>;
   const mockedGet = mockedApi.get as jest.Mock;
   const mockedPost = mockedApi.post as jest.Mock;
+  const mockedDelete = mockedApi.delete as jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -60,6 +62,21 @@ describe('WorkoutService', () => {
       );
 
       expect(result).toEqual(mockWorkout);
+    });
+  });
+
+  describe('remove workout by id', () => {
+    it('should call api.delete with correct url', async () => {
+      mockedDelete.mockResolvedValue({ data: { deleted: true } });
+
+      const workoutId = mockWorkout.id;
+
+      const result = await workoutService.removeWorkout(workoutId);
+
+      expect(mockedDelete).toHaveBeenCalledWith(
+        `${API_ENDPOINTS.WORKOUTS.ROOT}/${workoutId}`,
+      );
+      expect(result).toEqual({ deleted: true });
     });
   });
 });

--- a/frontend/src/services/workout.service.ts
+++ b/frontend/src/services/workout.service.ts
@@ -1,6 +1,11 @@
 import { api } from '@api';
 import { API_ENDPOINTS } from '@constants';
-import type { CreateWorkoutDto, IWorkout, WorkoutPreview } from '@types';
+import type {
+  CreateWorkoutDto,
+  IWorkout,
+  RemoveWorkoutResponse,
+  WorkoutPreview,
+} from '@types';
 
 class WorkoutService {
   async getAllWorkouts(): Promise<WorkoutPreview[]> {
@@ -17,6 +22,11 @@ class WorkoutService {
     const { data } = await api.get<IWorkout>(
       `${API_ENDPOINTS.WORKOUTS.ROOT}/${id}`,
     );
+    return data;
+  }
+
+  async removeWorkout(id: string): Promise<RemoveWorkoutResponse> {
+    const { data } = await api.delete(`${API_ENDPOINTS.WORKOUTS.ROOT}/${id}`);
     return data;
   }
 }

--- a/frontend/src/types/workouts.types.ts
+++ b/frontend/src/types/workouts.types.ts
@@ -27,3 +27,7 @@ export interface CreateWorkoutFormValues {
   date: string;
   exercises: IExercise[];
 }
+
+export interface RemoveWorkoutResponse {
+  deleted: boolean;
+}


### PR DESCRIPTION
## Description

Adds the ability to delete a workout directly from the workout details page. The view header now exposes a delete action, asks for confirmation before removal, then redirects back to the dashboard after a successful delete and refreshes the workouts list.

The frontend also adds delete-specific API service support, response typing, localized modal/toast copy, and focused tests for the delete mutation, hook behavior, and service call. A `ts` script was added for running TypeScript checks without emitting files.

## Related Issue

#22 

## Screenshot/Video

<!-- Add screenshots or video demonstrating the delete workout flow -->

## Configuration

No runtime configuration changes.

## Related PRs / Dependencies

Requires the workout delete API endpoint to be available on the backend.

## Testing

1. Open an existing workout details page and click the delete action in the sticky header.
2. Confirm the delete modal and verify the app redirects to the dashboard.
3. Verify the deleted workout is removed from the dashboard list and success toast is shown.
4. Force a delete API error and verify the user stays on the page and sees an error toast.
5. Run frontend tests for workout deletion and workout service coverage.