### PR TITLE
Filippovskii/tests/improve and docs

### DIFF
--- a/.agents/rules/frontend-testing.md
+++ b/.agents/rules/frontend-testing.md
@@ -74,6 +74,8 @@ Use queries in **strict priority order**:
 
 - **MUST NOT** use `container.querySelector` for primary assertions.
 - **SHOULD** prefer `within(container)` when multiple similar elements exist to ensure the test targets the correct instance.
+- **MUST** treat `data-testid` as an explicit fallback for UI that has no stable accessible surface, such as skeletons, decorative loaders, virtualized placeholders, or third-party markup where the accessible contract is intentionally absent.
+- **MUST** keep `data-testid` names domain-specific and stable when they are necessary. Prefer `workout-details-skeleton` over generic names like `loader` or `box-1`.
 
 ### 5.3 Accessibility attributes
 
@@ -95,10 +97,40 @@ Use queries in **strict priority order**:
 ## 6. Interaction & Async Rules
 
 - **MUST** use `@testing-library/user-event` for user interactions.
+- **MUST** prefer `userEvent` for real user flows: clicking buttons/links, typing, clearing inputs, tabbing, keyboard shortcuts, selecting options, uploading files, and opening menus/dialogs.
+- **MAY** use `fireEvent` only for low-level browser events that `userEvent` cannot express well, such as manually dispatching `scroll`, `resize`, `animationEnd`, `transitionEnd`, or custom events. Document why `fireEvent` is needed when the reason is not obvious.
 - **MUST** use `findBy*` for async appearance.
 - **MUST** use `waitFor` only with a concrete assertion inside.
 - **MUST** keep side effects **outside** `waitFor`.
 - **MUST** use `queryBy*` only for non-existence assertions.
+- **MUST NOT** put `user.click`, `user.type`, mock setup, route changes, or any other side effect inside `waitFor`.
+
+### 6.1 Network-driven UI states
+
+For React Query or request-driven screens, tests should assert the state transition that a user sees:
+
+1. Arrange the boundary mock/hook response.
+2. Assert the initial loading, empty, error, or disabled state when that state matters.
+3. Use `findBy*` for data that appears after the request settles.
+4. Use `waitFor` for non-DOM async state, such as `result.current.isSuccess`, or disappearance assertions that cannot be expressed with `findBy*`.
+5. Assert stale/absent UI with `queryBy*` after the concrete loaded/error state is visible.
+
+```ts
+render(<WorkoutPage />, { route: '/workouts/1' });
+
+expect(screen.getByTestId('workout-details-skeleton')).toBeInTheDocument();
+expect(await screen.findByRole('heading', { name: workoutName })).toBeVisible();
+expect(screen.queryByTestId('workout-details-skeleton')).not.toBeInTheDocument();
+```
+
+For hook tests, `waitFor` is acceptable when the observable contract is hook state:
+
+```ts
+const { result } = renderHook(() => useWorkoutQuery(id));
+
+await waitFor(() => expect(result.current.isSuccess).toBe(true));
+expect(result.current.data).toEqual(workout);
+```
 
 ---
 
@@ -181,6 +213,20 @@ act(() => {
 - **MUST** avoid flaky assertions and race-prone timing assumptions.
 - **SHOULD** keep tests small and parallelizable.
 - **SHOULD** avoid heavy setup per test when shared setup is possible.
+
+### 10.1 Flaky-pattern checklist
+
+Before finishing a frontend test change, verify:
+
+- No fixed sleeps, manual promises, or arbitrary timer advancement unless testing timer behavior directly.
+- No side effects inside `waitFor`.
+- `waitFor` always contains a concrete assertion.
+- Async UI appearance uses `findBy*` instead of `waitFor(() => getBy*)`.
+- Disappearance/absence uses `queryBy*` after a positive condition proves the UI reached the expected state.
+- Each render gets isolated providers and a fresh React Query client.
+- Mocks are reset in `beforeEach` and do not rely on test order.
+- Dropdowns, dialogs, popovers, and accordions are opened by the user flow before querying their contents.
+- Repeated regions use `within` so a test cannot pass against the wrong card, row, dialog, or list.
 
 ---
 
@@ -388,3 +434,30 @@ Include in the shared `Wrapper` only providers that are **required by the majori
 | Redux `<Provider store>` | project uses Redux; pass `store` as an option |
 
 Providers needed by only one or two tests **MUST NOT** be added to the global wrapper — use the `wrapper` option directly in that test instead.
+
+---
+
+## 15. MUI Component Testing
+
+The project uses MUI for form controls, dialogs, and selected UI primitives. MUI often renders through portals, applies transitions, and exposes accessible roles through composed components.
+
+- **MUST** query MUI controls by accessible role/name first: `button`, `textbox`, `combobox`, `dialog`, `option`, `menuitem`, `checkbox`, `tab`, `tabpanel`.
+- **MUST** open MUI menus, selects, autocomplete poppers, dialogs, and accordions through `userEvent` before querying their contents.
+- **MUST** use `findByRole` for portal or transition-rendered content that appears after an interaction.
+- **SHOULD** scope dialog assertions with `within(screen.getByRole('dialog'))` when the same labels also exist behind the modal.
+- **SHOULD** assert the visible behavior of MUI state instead of internal classes such as `.Mui-expanded`, `.Mui-selected`, or `.Mui-disabled`.
+- **MAY** use `fireEvent.mouseDown` only when a MUI primitive cannot be opened by `userEvent.click` because the component listens to a lower-level event. Prefer `userEvent` first and leave a short comment for the exception.
+- **MUST NOT** assert on portal container structure, transition wrapper nodes, generated ids, or MUI class names.
+
+Example:
+
+```ts
+const user = userEvent.setup();
+
+await user.click(screen.getByRole('button', { name: /delete workout/i }));
+
+const dialog = await screen.findByRole('dialog', { name: /delete workout/i });
+await user.click(within(dialog).getByRole('button', { name: /confirm/i }));
+
+expect(onConfirm).toHaveBeenCalledTimes(1);
+```

--- a/docs/frontend-testing-standards-update.md
+++ b/docs/frontend-testing-standards-update.md
@@ -1,0 +1,26 @@
+# Frontend Testing Standards Update
+
+## What changed
+
+- Expanded `.agents/rules/frontend-testing.md` with concrete rules for `userEvent` vs `fireEvent`, async request-driven UI, stable selector priority, MUI portals/transitions, and a flaky-test checklist.
+- Updated representative RTL tests in workout form and workout page specs to follow the standard:
+  - prefer `findBy*` for async appearance instead of `waitFor(() => getBy*)`;
+  - keep side effects outside `waitFor`;
+  - assert disabled/absent UI with semantic matchers;
+  - use project dictionary values instead of hardcoded copy;
+  - add count/absence checks where they prove the user-visible result.
+
+## Why it was fixed
+
+The old tests mostly worked, but some patterns were too easy to make flaky or misleading:
+
+- `waitFor` was used where `findBy*` expresses the same async UI expectation more clearly.
+- One page test said it verified submit behavior, but it only checked that the submit button existed. It now verifies the actual initial rule: the button is disabled until an exercise is selected.
+- Some assertions used copy literals even though the app already has locale constants.
+
+## Notes for future tests
+
+- Use `userEvent` for real user actions. Use `fireEvent` only for low-level events that `userEvent` cannot model.
+- Query by role/name first, then label/text, and use `data-testid` only for things like skeletons or non-semantic placeholders.
+- For MUI dialogs, menus, selects, and popovers, open the UI first and then query portal content with `findByRole`.
+- A test is not stable until async assertions wait for a concrete visible condition and negative assertions happen after the UI reached the expected state.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -103,6 +103,12 @@ Prefer Tailwind token utilities over arbitrary values. For example, use `min-h-c
 
 If a reusable value is needed in both Tailwind and MUI, add it to `tokens/design-tokens.json`, run `npm run tokens`, and consume it from Tailwind utilities or `PALETTE`.
 
+## Testing
+
+Frontend tests use Jest, React Testing Library, and `@testing-library/user-event` through `src/utils/testUtils.tsx`.
+
+Before adding or refactoring frontend tests, follow the repository testing standard in `../.agents/rules/frontend-testing.md`. The short update note in `../docs/frontend-testing-standards-update.md` summarizes the current conventions for `userEvent` vs `fireEvent`, async UI assertions, flaky-pattern checks, and MUI-specific pitfalls.
+
 ## References
 
 - Tailwind theme variables: https://tailwindcss.com/docs/theme

--- a/frontend/src/components/workout/form/specs/FormExerciseCard.spec.tsx
+++ b/frontend/src/components/workout/form/specs/FormExerciseCard.spec.tsx
@@ -1,4 +1,4 @@
-import { renderWithFormik, screen, userEvent, waitFor } from '@testUtils';
+import { renderWithFormik, screen, userEvent } from '@testUtils';
 import { DICTIONARY } from '@locales';
 import {
   BENCH_PRESS_NAME,
@@ -62,9 +62,9 @@ describe('FormExerciseCard', () => {
       }),
     );
 
-    await waitFor(() => {
-      expect(screen.getByText(`2 ${workoutLocales.sets}`)).toBeInTheDocument();
-    });
+    expect(
+      await screen.findByText(`2 ${workoutLocales.sets}`),
+    ).toBeInTheDocument();
 
     expect(screen.getAllByDisplayValue(completedSet.weight)).toHaveLength(2);
     expect(screen.getAllByDisplayValue(completedSet.reps)).toHaveLength(2);
@@ -93,9 +93,9 @@ describe('FormExerciseCard', () => {
       }),
     );
 
-    await waitFor(() => {
-      expect(screen.getByText(`1 ${workoutLocales.sets}`)).toBeInTheDocument();
-    });
+    expect(
+      await screen.findByText(`1 ${workoutLocales.sets}`),
+    ).toBeInTheDocument();
 
     expect(screen.getByDisplayValue(0)).toBeInTheDocument();
     expect(screen.getByDisplayValue(1)).toBeInTheDocument();
@@ -121,9 +121,9 @@ describe('FormExerciseCard', () => {
       }),
     );
 
-    await waitFor(() => {
-      expect(screen.getByText(`1 ${workoutLocales.sets}`)).toBeInTheDocument();
-    });
+    expect(
+      await screen.findByText(`1 ${workoutLocales.sets}`),
+    ).toBeInTheDocument();
 
     expect(screen.queryByDisplayValue(extraSet.weight)).not.toBeInTheDocument();
     expect(screen.queryByDisplayValue(extraSet.reps)).not.toBeInTheDocument();

--- a/frontend/src/components/workout/form/specs/FormExercisesList.spec.tsx
+++ b/frontend/src/components/workout/form/specs/FormExercisesList.spec.tsx
@@ -1,4 +1,4 @@
-import { renderWithFormik, screen, userEvent, waitFor } from '@testUtils';
+import { renderWithFormik, screen, userEvent } from '@testUtils';
 import { DICTIONARY } from '@locales';
 import {
   BENCH_PRESS_NAME,
@@ -26,20 +26,22 @@ const workoutLocales = DICTIONARY.workout;
 
 describe('FormExercisesList', () => {
   it('should render form exercise cards for current exercises', () => {
+    const exercises = [
+      createExercise({
+        name: BENCH_PRESS_NAME,
+      }),
+      createExercise({
+        id: 'exercise-2',
+        exerciseId: 'pull-up',
+        name: PULL_UP_NAME,
+      }),
+    ];
+
     renderWithFormik(<FormExercisesList />, {
-      initialValues: createWorkoutValues([
-        createExercise({
-          name: BENCH_PRESS_NAME,
-        }),
-        createExercise({
-          id: 'exercise-2',
-          exerciseId: 'pull-up',
-          name: PULL_UP_NAME,
-        }),
-      ]),
+      initialValues: createWorkoutValues(exercises),
     });
 
-    expect(screen.getAllByRole('heading')).toHaveLength(2);
+    expect(screen.getAllByRole('heading')).toHaveLength(exercises.length);
     expect(
       screen.getByRole('heading', {
         name: BENCH_PRESS_NAME,
@@ -75,6 +77,7 @@ describe('FormExercisesList', () => {
         name: selectedExercise.name,
       }),
     ).toBeInTheDocument();
+    expect(screen.getAllByRole('heading')).toHaveLength(1);
     expect(screen.getByText(`1 ${workoutLocales.sets}`)).toBeInTheDocument();
     expect(screen.getByDisplayValue(0)).toBeInTheDocument();
     expect(screen.getByDisplayValue(1)).toBeInTheDocument();
@@ -99,8 +102,6 @@ describe('FormExercisesList', () => {
       }),
     );
 
-    await waitFor(() => {
-      expect(screen.queryByRole('heading')).not.toBeInTheDocument();
-    });
+    expect(screen.queryByRole('heading')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/workout/specs/CreateWorkoutPage.spec.tsx
+++ b/frontend/src/pages/workout/specs/CreateWorkoutPage.spec.tsx
@@ -1,7 +1,8 @@
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { APP_ROUTES } from '@constants';
-import { render, screen } from '@testUtils';
+import { DICTIONARY } from '@locales';
+import { render, screen, waitFor } from '@testUtils';
 import CreateWorkoutPage from '../create/CreateWorkoutPage';
 import { useCreateWorkout } from '../create/hooks';
 
@@ -25,6 +26,7 @@ describe('CreateWorkoutPage', () => {
 
   const mockDate = '2023-10-27';
   const basePath = '/workout/create';
+  const workoutCreateLocales = DICTIONARY.workout.create;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -40,15 +42,19 @@ describe('CreateWorkoutPage', () => {
     expect(mockNavigate).toHaveBeenCalledWith(APP_ROUTES.DASHBOARD);
   });
 
-  it('should render Formik and submit correctly when button clicked', async () => {
+  it('should render disabled submit button until an exercise is selected', async () => {
     mockedUseSearchParams.mockReturnValue([
       new URLSearchParams(`?date=${mockDate}`),
     ]);
 
     render(<CreateWorkoutPage />, { route: `${basePath}?date=${mockDate}` });
 
-    expect(
-      screen.getByRole('button', { name: /Finish Workout/i }),
-    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', {
+          name: workoutCreateLocales.submitButton,
+        }),
+      ).toBeDisabled();
+    });
   });
 });

--- a/frontend/src/utils/testUtils.tsx
+++ b/frontend/src/utils/testUtils.tsx
@@ -9,7 +9,7 @@ import {
 import userEvent from '@testing-library/user-event';
 import { Formik, type FormikConfig, type FormikValues } from 'formik';
 import type { ReactElement, ReactNode } from 'react';
-import { MemoryRouter, Routes } from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 
 import { appTheme } from '@theme';
 
@@ -39,7 +39,6 @@ export const renderWithProviders = (
       <QueryClientProvider client={queryClient}>
         <ThemeProvider theme={appTheme}>
           <MemoryRouter initialEntries={[route]}>
-            <Routes></Routes>
             {children}
           </MemoryRouter>
         </ThemeProvider>

--- a/frontend/src/utils/testUtils.tsx
+++ b/frontend/src/utils/testUtils.tsx
@@ -38,9 +38,7 @@ export const renderWithProviders = (
     return (
       <QueryClientProvider client={queryClient}>
         <ThemeProvider theme={appTheme}>
-          <MemoryRouter initialEntries={[route]}>
-            {children}
-          </MemoryRouter>
+          <MemoryRouter initialEntries={[route]}>{children}</MemoryRouter>
         </ThemeProvider>
       </QueryClientProvider>
     );


### PR DESCRIPTION
## Description

This PR strengthens frontend testing conventions for the React/Jest/RTL test suite. It documents when to use `userEvent`, `fireEvent`, `findBy`, and `waitFor`, adds guidance for request-driven UI and MUI components, and updates representative workout tests to follow those conventions. It also removes noisy router warnings from the shared test wrapper.

## Issue

#103 

## Testing

1. Frontend test suite
   Preconditions: Dependencies are installed and the frontend workspace is available.
   Actions: Run `npm test` from `frontend/`.
   Expected result: All Jest suites pass with coverage thresholds satisfied.

2. Workout form set interactions
   Preconditions: Existing workout form tests are run.
   Actions: Add a set, add a default set for an exercise without sets, and remove an extra set through the tested UI interactions.
   Expected result: Tests wait for user-visible results with `findBy*`, assert the correct set counts, and verify removed values are absent.

3. Create workout submit state
   Preconditions: Create workout page is rendered with a `date` query parameter and no selected exercises.
   Actions: Render the page test.
   Expected result: The submit button is located by localized label and asserted disabled after Formik validation settles.

4. Testing documentation
   Preconditions: Reviewer opens frontend docs.
   Actions: Read `frontend/README.md`, `.agents/rules/frontend-testing.md`, and `docs/frontend-testing-standards-update.md`.
   Expected result: Frontend docs point to the testing standard, and the standard includes flaky-test and MUI-specific guidance.